### PR TITLE
Use user agent string to detect Firefox

### DIFF
--- a/extension/constants.js
+++ b/extension/constants.js
@@ -47,7 +47,7 @@ DEFAULT_EXTENSION_SETTINGS = {
     }
 };
 
-IS_FIREFOX = (typeof InstallTrigger !== "undefined"); // heh.
+IS_FIREFOX = (navigator && navigator.userAgent || '').toLowerCase().match(/(?:firefox|fxios)/) !== null;
 
 // NOTE if you change this, make sure to adjust the error message shown in action_popup.html
 SUPPORTED_PLATFORMS = ["linux", "openbsd", "freebsd"];


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1754441

InstallTrigger is going away. This line currently issues a warning and is likely to entirely not work in the future. The proposed code work I believe should work also with Firefox forks such as IceWeasel