### PR TITLE
A scrollbar appears on personal pages on VK.com

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -125,13 +125,6 @@ function loadBreezeScrollBars() {
     // "Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules"
     var styleTag = document.createElement("style");
     styleTag.appendChild(document.createTextNode(`
-html::-webkit-scrollbar {
-    /* we'll add padding as "border" in the thumb*/
-    height: 20px;
-    width: 20px;
-    background: white;
-}
-
 html::-webkit-scrollbar-track {
     border-radius: 20px;
     border: 7px solid white; /* FIXME why doesn't "transparent" work here?! */


### PR DESCRIPTION
Check my personal page: https://vk.com/vokamut

With styles:
![2023-09-14_09-26](https://github.com/KDE/plasma-browser-integration/assets/4266448/75f401f5-3f3f-4194-9b6a-979078405c36)

Without styles:
![2023-09-14_09-26_1](https://github.com/KDE/plasma-browser-integration/assets/4266448/7c433df1-75f2-4a55-bc80-d135009d5fa9)

Also, the scrollbar becomes white, rather than adapting to the theme.
