### PR TITLE
Install native messaging host manifest to Glide browser directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ add_feature_info(MOZILLA_DIR On "Mozilla directory is '${MOZILLA_DIR}'")
 set(LIBREWOLF_DIR "${CMAKE_INSTALL_PREFIX}/lib/librewolf" CACHE STRING "LibreWolf directory")
 add_feature_info(LIBREWOLF_DIR On "LibreWolf directory is '${LIBREWOLF_DIR}'")
 
+set(GLIDE_DIR "${CMAKE_INSTALL_PREFIX}/lib/glide-browser" CACHE STRING "Glide directory")
+add_feature_info(GLIDE_DIR On "Glide directory is '${GLIDE_DIR}'")
+
 add_subdirectory(host)
 add_subdirectory(reminder)
 add_subdirectory(flatpak-integrator)
@@ -106,10 +109,13 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.chrome_integration.json
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.firefox_integration.json DESTINATION ${MOZILLA_DIR}/native-messaging-hosts/ RENAME org.kde.plasma.browser_integration.json)
 # LibreWolf
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.firefox_integration.json DESTINATION ${LIBREWOLF_DIR}/native-messaging-hosts/ RENAME org.kde.plasma.browser_integration.json)
+# Glide
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.firefox_integration.json DESTINATION ${GLIDE_DIR}/native-messaging-hosts/ RENAME org.kde.plasma.browser_integration.json)
 
 if (COPY_MESSAGING_HOST_FILE_HOME)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.firefox_integration.json DESTINATION $ENV{HOME}/.mozilla/native-messaging-hosts/ RENAME org.kde.plasma.browser_integration.json)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.firefox_integration.json DESTINATION $ENV{HOME}/.librewolf/native-messaging-hosts/ RENAME org.kde.plasma.browser_integration.json)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.firefox_integration.json DESTINATION $ENV{HOME}/.glide-browser/native-messaging-hosts/ RENAME org.kde.plasma.browser_integration.json)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.chrome_integration.json DESTINATION $ENV{HOME}/.config/chromium/NativeMessagingHosts/ RENAME org.kde.plasma.browser_integration.json)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.chrome_integration.json DESTINATION $ENV{HOME}/.config/google-chrome/NativeMessagingHosts/ RENAME org.kde.plasma.browser_integration.json)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.kde.plasma.chrome_integration.json DESTINATION $ENV{HOME}/.config/microsoft-edge/NativeMessagingHosts/ RENAME org.kde.plasma.browser_integration.json)


### PR DESCRIPTION
[Glide](https://glide-browser.app/) is a new Firefox-based browser.

This change installs the native messaging host manifest into its directory structure so that the browser integration extension can work correctly with Glide.